### PR TITLE
Add skeleton doc site

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally, but recommended,
+# declare the Python requirements required to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # metrax
 
 `metrax` is an official JAX metrics library.
+
+## Development
+
+Develop the docs locally:
+
+```
+sphinx-build ./docs /tmp/metrax_docs
+python -m http.server --directory /tmp/metrax_docs
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,49 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration file for the Sphinx documentation builder."""
+
+# -- Project information
+
+project = 'metrax'
+copyright = '2025, The metrax Authors'
+author = 'The metrax Authors'
+
+release = '0.0.2'
+version = '0.0.2'
+
+
+# -- General configuration
+
+extensions = [
+    'sphinx.ext.duration',
+    'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.napoleon',
+]
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
+}
+intersphinx_disabled_domains = ['std']
+
+templates_path = ['_templates']
+
+# -- Options for HTML output
+
+html_theme = 'sphinx_rtd_theme'
+
+# -- Options for EPUB output
+epub_show_urls = 'footnote'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,8 @@
+metrax Documentation
+=====================
+
+**metrax** provides common evaluation metric implementations for JAX.
+
+.. note::
+
+   This project is under active development.


### PR DESCRIPTION
Adding these files is necessary to get ReadTheDocs to auto-generate the doc site.

Manually generated version to verify:

<img width="1175" alt="image" src="https://github.com/user-attachments/assets/4a3fa7b7-f712-4977-8e8f-4443cc962597" />
