### PR TITLE
Update imports to be modules not classes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,9 @@ Please make sure that your PR passes all tests by running `pytest ./src/` on you
 local machine. Also, you can run only tests that are affected by your code
 changes, but you will need to select them manually.
 
+Metrax uses [ruff](https://github.com/astral-sh/ruff) for linting. Before
+sending a PR please run `ruff check` to catch any issues.
+
 ## Community Guidelines
 
 This project follows [Google's Open Source Community

--- a/src/metrax/__init__.py
+++ b/src/metrax/__init__.py
@@ -12,38 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from metrax.base import (
-    Average,
-)
-from metrax.classification_metrics import (
-    AUCPR,
-    AUCROC,
-    Precision,
-    Recall,
-)
-from metrax.nlp_metrics import (
-    Perplexity,
-    WER
-)
-from metrax.ranking_metrics import (
-    AveragePrecisionAtK,
-)
-from metrax.regression_metrics import (
-    MSE,
-    RMSE,
-    RSQUARED,
-)
+from metrax import base
+from metrax import classification_metrics
+from metrax import nlp_metrics
+from metrax import ranking_metrics
+from metrax import regression_metrics
 
-__all__ = [
-    "AUCPR",
-    "AUCROC",
-    "Average",
-    "AveragePrecisionAtK",
-    "MSE",
-    "Perplexity",
-    "Precision",
-    "Recall",
-    "RMSE",
-    "RSQUARED",
-    "WER",
-]
+Average = base.Average
+AUCPR = classification_metrics.AUCPR
+AUCROC = classification_metrics.AUCROC
+Precision = classification_metrics.Precision
+Recall = classification_metrics.Recall
+Perplexity = nlp_metrics.Perplexity
+WER = nlp_metrics.WER
+AveragePrecisionAtK = ranking_metrics.AveragePrecisionAtK
+MSE = regression_metrics.MSE
+RMSE = regression_metrics.RMSE
+RSQUARED = regression_metrics.RSQUARED

--- a/src/metrax/nnx/__init__.py
+++ b/src/metrax/nnx/__init__.py
@@ -12,30 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from metrax.nnx.nnx_metrics import (
-    AUCPR,
-    AUCROC,
-    Average,
-    AveragePrecisionAtK,
-    MSE,
-    Perplexity,
-    Precision,
-    RMSE,
-    RSQUARED,
-    Recall,
-    WER,
-)
+from metrax.nnx import nnx_metrics
 
-__all__ = [
-    "AUCPR",
-    "AUCROC",
-    "Average",
-    "AveragePrecisionAtK",
-    "MSE",
-    "Perplexity",
-    "Precision",
-    "Recall",
-    "RMSE",
-    "RSQUARED",
-    "WER",
-]
+AUCPR = nnx_metrics.AUCPR
+AUCROC = nnx_metrics.AUCROC
+Average = nnx_metrics.Average
+AveragePrecisionAtK = nnx_metrics.AveragePrecisionAtK
+MSE = nnx_metrics.MSE
+Perplexity = nnx_metrics.Perplexity
+Precision = nnx_metrics.Precision
+RMSE = nnx_metrics.RMSE
+RSQUARED = nnx_metrics.RSQUARED
+Recall = nnx_metrics.Recall
+WER = nnx_metrics.WER


### PR DESCRIPTION
This aligns with the Google style guide:
https://google.github.io/styleguide/pyguide.html#22-imports

Also remove `__all__` from `__init__.py` files. This only applies when using `import *`, which is not common or recommended, so it's not worth us protecting against within the library.