### PR TITLE
Perplexity: add clipping and from_logits

### DIFF
--- a/src/metrax/base_test.py
+++ b/src/metrax/base_test.py
@@ -14,6 +14,9 @@
 
 """Tests for metrax base utilities."""
 
+import os
+os.environ['KERAS_BACKEND'] = 'jax'
+
 from absl.testing import absltest
 from absl.testing import parameterized
 import jax.numpy as jnp

--- a/src/metrax/regression_metrics.py
+++ b/src/metrax/regression_metrics.py
@@ -203,7 +203,7 @@ class RSQUARED(clu_metrics.Metric):
     )
 
   def compute(self) -> jax.Array:
-    """Computes the r-squared score.
+    r"""Computes the r-squared score.
 
     Since we don't know the mean of the labels before we aggregate all of the
     data, we will manipulate the formula to be:

--- a/src/metrax/regression_metrics_test.py
+++ b/src/metrax/regression_metrics_test.py
@@ -15,6 +15,8 @@
 """Tests for metrax regression metrics."""
 
 import os
+os.environ['KERAS_BACKEND'] = 'jax'
+
 from absl.testing import absltest
 from absl.testing import parameterized
 import jax


### PR DESCRIPTION
It was pointed out that Perplexity returns NaNs for negative values. This is because our implementation did not clip logit values to [0, 1], whereas the Keras implementation does. [1]

Even with that fix, the tests were failing because Keras defaults to the TensorFlow version of the metric, which applies softmax to the outputs unconditionally [2], unlike the JAX implementation which does not. [3]

Also:

- Added a `from_logits` arg, similar to Keras, for users who want to pass raw logits and have us apply softmax internally.
- Forced all Keras metrics in tests to use the JAX backend for parity.

[1] https://github.com/keras-team/keras/blob/3f8b065e82b17884bd43fcfbd4bd79f18a7019fe/keras/src/backend/jax/nn.py#L582
[2] https://www.tensorflow.org/api_docs/python/tf/nn/sparse_softmax_cross_entropy_with_logits
[3] https://github.com/keras-team/keras/blob/3f8b065e82b17884bd43fcfbd4bd79f18a7019fe/keras/src/backend/jax/nn.py#L578-L579