### PR TITLE
remove tf from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,3 @@ jax[cpu]
 keras-hub
 pytest
 scikit-learn
-tensorflow-cpu~=2.18
-tensorflow-text~=2.18


### PR DESCRIPTION
Now that we are setting keras backend to JAX, we can remove tf dependency.