### PR TITLE
add psnr to metrax

### DIFF
--- a/src/metrax/__init__.py
+++ b/src/metrax/__init__.py
@@ -41,6 +41,7 @@ RecallAtK = ranking_metrics.RecallAtK
 RougeL = nlp_metrics.RougeL
 RougeN = nlp_metrics.RougeN
 SSIM = image_metrics.SSIM
+PSNR = image_metrics.PSNR
 WER = nlp_metrics.WER
 
 
@@ -67,5 +68,6 @@ __all__ = [
     "RougeL",
     "RougeN",
     "SSIM",
+    "PSNR",
     "WER",
 ]

--- a/src/metrax/image_metrics.py
+++ b/src/metrax/image_metrics.py
@@ -524,7 +524,7 @@ class PSNR(base.Average):
         img1: jnp.ndarray,
         img2: jnp.ndarray,
         max_val: float,
-        eps: float = 1e-12,
+        eps: float = 0,
   ) -> jnp.ndarray:
     """Computes PSNR (Peak Signal-to-Noise Ratio) values.
     


### PR DESCRIPTION
### Summary [Issue #86 ]

- Added PSNR metric as a part of Image Metrics to metrax.
-  Reused test cases from SSIM to test PSNR
-  Added an ε-guard with a default value 0 to mirror Tensorflow behavior. TF returns inf when the images are identical (MSE==0).The ε-guard can clamp mse = max(mse,ε ) so the result is a huge but finite value, which avoids nan/inf explosions during averaging & logging. However, at the momennt, I've just initialized it to 0 to mirror TF behavior