### PR TITLE
add PSNR to metrax (#86)

### DIFF
--- a/src/metrax/__init__.py
+++ b/src/metrax/__init__.py
@@ -41,6 +41,7 @@ RecallAtK = ranking_metrics.RecallAtK
 RougeL = nlp_metrics.RougeL
 RougeN = nlp_metrics.RougeN
 SSIM = image_metrics.SSIM
+PSNR = image_metrics.PSNR
 WER = nlp_metrics.WER
 
 
@@ -67,5 +68,6 @@ __all__ = [
     "RougeL",
     "RougeN",
     "SSIM",
+    "PSNR",
     "WER",
 ]

--- a/src/metrax/__init__.py
+++ b/src/metrax/__init__.py
@@ -34,6 +34,7 @@ NDCGAtK = ranking_metrics.NDCGAtK
 Perplexity = nlp_metrics.Perplexity
 Precision = classification_metrics.Precision
 PrecisionAtK = ranking_metrics.PrecisionAtK
+PSNR = image_metrics.PSNR
 RMSE = regression_metrics.RMSE
 RSQUARED = regression_metrics.RSQUARED
 Recall = classification_metrics.Recall
@@ -41,7 +42,6 @@ RecallAtK = ranking_metrics.RecallAtK
 RougeL = nlp_metrics.RougeL
 RougeN = nlp_metrics.RougeN
 SSIM = image_metrics.SSIM
-PSNR = image_metrics.PSNR
 WER = nlp_metrics.WER
 
 

--- a/src/metrax/__init__.py
+++ b/src/metrax/__init__.py
@@ -61,6 +61,7 @@ __all__ = [
     "Perplexity",
     "Precision",
     "PrecisionAtK",
+    "PSNR",
     "RMSE",
     "RSQUARED",
     "Recall",
@@ -68,6 +69,5 @@ __all__ = [
     "RougeL",
     "RougeN",
     "SSIM",
-    "PSNR",
     "WER",
 ]

--- a/src/metrax/image_metrics.py
+++ b/src/metrax/image_metrics.py
@@ -508,16 +508,24 @@ class IoU(base.Average):
         epsilon=epsilon,
     )
     return super().from_model_output(values=iou_score)
+
+
 @flax.struct.dataclass
 class PSNR(base.Average):
   r"""
-  Peak Signal-to-Noise Ratio (PSNR) Metric.
+  PSNR (Peak Signal-to-Noise Ratio)  Metric.
   
-    Given two images *x* and *y*, PSNR is defined as::
+  This class calculates the Peak Signal-to-Noise Ratio (PSNR) between two images
+  to measure the quality of a reconstructed image compared to a reference.
+  
+  .. math::
 
-      PSNR(x, y) = 20 * log10(max_val) - 10 * log10(MSE(x, y))
+      \text{PSNR}(I, J) = 10 \cdot \log_{10} \left( \frac{\max(I)^2}{\text{MSE}(I, J)} \right)
 
-    where MSE is the mean‑squared error computed over all pixels and channels.
+  Where:
+    - :math:`\max(I)` is the maximum possible pixel value of the input image.
+    - :math:`\text{MSE}(I, J)` is the mean squared error between images :math:`I` and :math:`J`.
+    
   """ 
   @staticmethod
   def _calculate_psnr(
@@ -546,11 +554,10 @@ class PSNR(base.Average):
               f"Inputs must be 4‑D (batch, height, width, channels), got {img1.ndim}‑D."
           )
 
-      # Cast to float32 to avoid overflow/underflow issues in MSE and log.
     img1 = img1.astype(jnp.float32)
     img2 = img2.astype(jnp.float32)
 
-      # Mean‑squared error per image.
+    # Mean‑squared error per image.
     mse = jnp.mean(jnp.square(img1 - img2), axis=(1, 2, 3))
     mse = jnp.maximum(mse, eps)
 
@@ -560,9 +567,9 @@ class PSNR(base.Average):
   @classmethod
   def from_model_output(  
       cls,
-      predictions: jnp.ndarray,   # Represents predicted images (y_pred)
-      targets: jnp.ndarray, # Represents ground truth images (y_true)
-      max_val: float, # Dynamic range of pixel values
+      predictions: jnp.ndarray,
+      targets: jnp.ndarray,
+      max_val: float,
   ) -> 'PSNR':
       """Computes PSNR for a batch of images and creates an PSNR metric instance.
       

--- a/src/metrax/image_metrics.py
+++ b/src/metrax/image_metrics.py
@@ -524,7 +524,7 @@ class PSNR(base.Average):
         img1: jnp.ndarray,
         img2: jnp.ndarray,
         max_val: float,
-        eps: float = 1e-12,
+        eps: float = 0,
   ) -> jnp.ndarray:
     """Computes PSNR (Peak Signal-to-Noise Ratio) values.
     

--- a/src/metrax/image_metrics_test.py
+++ b/src/metrax/image_metrics_test.py
@@ -69,6 +69,12 @@ PREDS_5 = np.random.rand(*IMG_SHAPE_5).astype(np.float32)
 TARGETS_5 = np.copy(PREDS_5)  # Identical images
 MAX_VAL_5 = 1.0
 
+# Case 6: Large batch size 
+IMG_SHAPE_6 = (8, 16, 16, 3)
+PREDS_6 = np.random.rand(*IMG_SHAPE_6).astype(np.float32)
+TARGETS_6 = np.random.rand(*IMG_SHAPE_6).astype(np.float32)
+MAX_VAL_6 = 1.0
+
 B_IOU, H_IOU, W_IOU = 2, 4, 4  # Common batch, height, width for IoU tests
 
 # Case IoU 1: Binary segmentation (num_classes=2), target_class_ids=[1] (foreground)
@@ -450,6 +456,12 @@ class ImageMetricsTest(parameterized.TestCase):
             TARGETS_4,
             MAX_VAL_4,
         ),
+        (
+            "psnr_large_batch",
+            PREDS_6,
+            TARGETS_6,
+            MAX_VAL_6,
+        ),
     )
   def test_psnr_against_tensorflow(
         self,
@@ -463,14 +475,14 @@ class ImageMetricsTest(parameterized.TestCase):
         Note: TensorFlow returns `inf` for identical images (MSE=0).
         Metrax returns a very large finite value due to the eps guard. 
         """
-        # Calculate PNSR using Metrax
+        # Calculate PSNR using Metrax
         metrax_psnr = metrax.PSNR.from_model_output(
             predictions=jnp.array(predictions_np),
             targets=jnp.array(targets_np),
             max_val=max_val,
         ).compute()
 
-        # Calculate PNSR using TensorFlow 
+        # Calculate PSNR using TensorFlow 
         tf_psnr = tf.image.psnr(
             predictions_np.astype(np.float32),
             targets_np.astype(np.float32),
@@ -478,10 +490,15 @@ class ImageMetricsTest(parameterized.TestCase):
         )
         tf_mean = tf.reduce_mean(tf_psnr).numpy()
 
-        if np.isfinite(tf_mean):
-            np.testing.assert_allclose(metrax_psnr, tf_mean, rtol=1e-4, atol=1e-4)
+        if np.isinf(tf_mean):
+            self.assertTrue(np.isinf(metrax_psnr))
         else:
-            self.assertTrue(metrax_psnr > 120.0)  # ~120 dB for mse=1e-12, max_val=1
-
+            np.testing.assert_allclose(
+                metrax_psnr,
+                tf_mean,
+                rtol=1e-4,
+                atol=1e-4,
+                err_msg="PSNR mismatch",
+    )
 if __name__ == '__main__':
   absltest.main()

--- a/src/metrax/image_metrics_test.py
+++ b/src/metrax/image_metrics_test.py
@@ -431,6 +431,7 @@ class ImageMetricsTest(parameterized.TestCase):
             delta=1e-6,
             msg=f'Keras IoU failed for {self.id()}',
         )
+        
   @parameterized.named_parameters(
         (
             "psnr_basic_norm_single_channel",
@@ -469,7 +470,6 @@ class ImageMetricsTest(parameterized.TestCase):
         targets_np: np.ndarray,
         max_val: float,
     ) -> None:
-
         """Test that metrax.SSIM computes values close to tf.image.ssim.
 
         Note: TensorFlow returns `inf` for identical images (MSE=0).

--- a/src/metrax/image_metrics_test.py
+++ b/src/metrax/image_metrics_test.py
@@ -425,7 +425,63 @@ class ImageMetricsTest(parameterized.TestCase):
             delta=1e-6,
             msg=f'Keras IoU failed for {self.id()}',
         )
+  @parameterized.named_parameters(
+        (
+            "psnr_basic_norm_single_channel",
+            PREDS_1,
+            TARGETS_1,
+            MAX_VAL_1,
+        ),
+        (
+            "psnr_multichannel_norm",
+            PREDS_2,
+            TARGETS_2,
+            MAX_VAL_2,
+        ),
+        (
+            "psnr_uint8_range_single_channel",
+            PREDS_3,
+            TARGETS_3,
+            MAX_VAL_3,
+        ),
+        (
+            "psnr_identical_images",
+            PREDS_4,
+            TARGETS_4,
+            MAX_VAL_4,
+        ),
+    )
+  def test_psnr_against_tensorflow(
+        self,
+        predictions_np: np.ndarray,
+        targets_np: np.ndarray,
+        max_val: float,
+    ) -> None:
 
+        """Test that metrax.SSIM computes values close to tf.image.ssim.
+
+        Note: TensorFlow returns `inf` for identical images (MSE=0).
+        Metrax returns a very large finite value due to the eps guard. 
+        """
+        # Calculate PNSR using Metrax
+        metrax_psnr = metrax.PSNR.from_model_output(
+            predictions=jnp.array(predictions_np),
+            targets=jnp.array(targets_np),
+            max_val=max_val,
+        ).compute()
+
+        # Calculate PNSR using TensorFlow 
+        tf_psnr = tf.image.psnr(
+            predictions_np.astype(np.float32),
+            targets_np.astype(np.float32),
+            max_val=max_val,
+        )
+        tf_mean = tf.reduce_mean(tf_psnr).numpy()
+
+        if np.isfinite(tf_mean):
+            np.testing.assert_allclose(metrax_psnr, tf_mean, rtol=1e-4, atol=1e-4)
+        else:
+            self.assertTrue(metrax_psnr > 120.0)  # ~120 dB for mse=1e-12, max_val=1
 
 if __name__ == '__main__':
   absltest.main()

--- a/src/metrax/metrax_test.py
+++ b/src/metrax/metrax_test.py
@@ -41,7 +41,7 @@ STRING_REFS = [
     'the quick brown fox jumps over the lazy dog',
     'hello beautiful world',
 ]
-# For image_metrics.SSIM.
+# For image_metrics.SSIM and image_metrics.PSNR.
 IMG_SHAPE = (4, 32, 32, 3)
 PRED_IMGS = np.random.rand(*IMG_SHAPE).astype(np.float32)
 TARGET_IMGS = np.random.rand(*IMG_SHAPE).astype(np.float32)
@@ -155,6 +155,14 @@ class MetraxTest(parameterized.TestCase):
               'ks': KS,
           },
       ),
+      (
+          'psnr',
+          metrax.PSNR,
+          {
+              'predictions': PRED_IMGS,
+              'targets': TARGET_IMGS,
+              'max_val': MAX_IMG_VAL,
+          },),
       (
           'rmse',
           metrax.RMSE,

--- a/src/metrax/nnx/__init__.py
+++ b/src/metrax/nnx/__init__.py
@@ -29,6 +29,7 @@ NDCGAtK = nnx_metrics.NDCGAtK
 Perplexity = nnx_metrics.Perplexity
 Precision = nnx_metrics.Precision
 PrecisionAtK = nnx_metrics.PrecisionAtK
+PSNR = nnx_metrics.PSNR
 RMSE = nnx_metrics.RMSE
 RSQUARED = nnx_metrics.RSQUARED
 Recall = nnx_metrics.Recall
@@ -54,6 +55,7 @@ __all__ = [
     "Perplexity",
     "Precision",
     "PrecisionAtK",
+    "PSNR",
     "RMSE",
     "RSQUARED",
     "Recall",

--- a/src/metrax/nnx/nnx_metrics.py
+++ b/src/metrax/nnx/nnx_metrics.py
@@ -122,6 +122,13 @@ class PrecisionAtK(NnxWrapper):
     super().__init__(metrax.PrecisionAtK)
 
 
+class PSNR(NnxWrapper):
+  """An NNX class for the Metrax metric PSNR."""
+
+  def __init__(self):
+    super().__init__(metrax.PSNR)
+
+    
 class Recall(NnxWrapper):
   """An NNX class for the Metrax metric Recall."""
 


### PR DESCRIPTION
### Summary [Issue #86 ]

- Added PSNR metric as a part of Image Metrics to metrax.
-  Reused test cases from SSIM to test PSNR
-  Added an ε-guard with a default value 0 to mirror Tensorflow behavior. TF returns inf when the images are identical (MSE==0).The ε-guard can clamp mse = max(mse,ε ) so the result is a huge but finite value, which avoids nan/inf explosions during averaging & logging. However, at the momennt, I've just initialized it to 0 to mirror TF behavior

## Updates
- Added test in mertax_test.py for testing PSNR's jittability
- Made the docstrings math equations Sphinx compliant and made them more clear and informative
- Fixed minor nits
- Passed Lint checking using Ruff [As per contributing instructions]
-  Added test for a large batch size [batch_size = 8]
