### PR TITLE
Auto-expand navigation in sidebar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,14 @@ templates_path = ['_templates']
 # -- Options for HTML output
 
 html_theme = 'sphinx_rtd_theme'
+html_theme_options = {
+    'collapse_navigation': False,
+    'navigation_depth': 2,
+}
+html_static_path = ['static']
+html_js_files = [
+    'custom.js',
+]
 
 # -- Options for EPUB output
 epub_show_urls = 'footnote'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,13 +3,14 @@ metrax Documentation
 
 **metrax** provides common evaluation metric implementations for JAX.
 
-Available Metrics
+Table of Contents
 -----------------
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
-   Metrax metrics: <metrax>
+   Metrax metrics <metrax>
+
 
 Getting Started
 ---------------

--- a/docs/static/custom.js
+++ b/docs/static/custom.js
@@ -1,0 +1,5 @@
+window.addEventListener('load', (_event) => {
+  document.querySelectorAll(".toctree-l1").forEach(node => {
+    node.classList.add("current");
+  })
+});


### PR DESCRIPTION
Fixes #85 

According to https://github.com/readthedocs/sphinx_rtd_theme/issues/455 the only way to do this is is via JS.

Demo:
<img width="1132" alt="image" src="https://github.com/user-attachments/assets/1e36d68d-11c5-4c5f-b790-9efb7d9d9913" />
