### PR TITLE
Make linting stricter and fix any violating lines

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,6 @@ import sys
 
 # Import local version of metrax.
 sys.path.insert(0, os.path.abspath('../src'))
-print('DEBUG: PATH', sys.path)
 
 # -- Project information
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,11 @@ packages = ["src/metrax"]
 [project.urls]
 Homepage = "https://github.com/google/metrax"
 Issues = "https://github.com/google/metrax/issues"
+
+[tool.ruff]
+indent-width = 2
+line-length = 120
+
+[tool.ruff.lint]
+# TODO(jeffcarp): Add "I", "NPY"
+select = ["B", "E", "F", "N", "PYI", "T20", "TID", "SIM", "W"]

--- a/src/metrax/classification_metrics.py
+++ b/src/metrax/classification_metrics.py
@@ -454,16 +454,14 @@ class AUCPR(clu_metrics.Metric):
 
 @flax.struct.dataclass
 class AUCROC(clu_metrics.Metric):
-  r"""Computes area under the receiver operation characteristic curve for binary classification given `predictions` and `labels`.
+  r"""Computes area under the receiver operation characteristic curve for
+  binary classification given `predictions` and `labels`.
 
   The ROC curve shows the tradeoff between the true positive rate (TPR) and
-  false positive
-  rate (FPR) at different classification thresholds. The area under this curve
-  (AUC-ROC)
-  provides a single score that represents the model's ability to discriminate
-  between
-  positive and negative cases across all possible classification thresholds,
-  regardless of class imbalance.
+  false positive rate (FPR) at different classification thresholds. The area
+  under this curve (AUC-ROC) provides a single score that represents the
+  model's ability to discriminate between positive and negative cases across
+  all possible classification thresholds, regardless of class imbalance.
 
   For each threshold :math:`t`, TPR and FPR are calculated as:
 

--- a/src/metrax/classification_metrics_test.py
+++ b/src/metrax/classification_metrics_test.py
@@ -77,7 +77,7 @@ class ClassificationMetricsTest(parameterized.TestCase):
     self.assertEqual(m.false_positives, jnp.array(0, jnp.float32))
     self.assertEqual(m.false_negatives, jnp.array(0, jnp.float32))
     self.assertEqual(m.num_thresholds, 0)
-    
+
   @parameterized.named_parameters(
       ('basic_f16', OUTPUT_LABELS, OUTPUT_PREDS_F16, SAMPLE_WEIGHTS),
       ('basic_f32', OUTPUT_LABELS, OUTPUT_PREDS_F32, SAMPLE_WEIGHTS),

--- a/src/metrax/nlp_metrics.py
+++ b/src/metrax/nlp_metrics.py
@@ -700,10 +700,7 @@ class WER(base.Average):
     # Fill the matrix
     for i in range(1, m + 1):
       for j in range(1, n + 1):
-        if prediction[i - 1] == reference[j - 1]:
-          cost = 0
-        else:
-          cost = 1
+        cost = 0 if prediction[i - 1] == reference[j - 1] else 1
 
         distance_matrix[i][j] = min(
             distance_matrix[i - 1][j] + 1,  # deletion

--- a/src/metrax/nnx/nnx_metrics.py
+++ b/src/metrax/nnx/nnx_metrics.py
@@ -135,7 +135,7 @@ class PSNR(NnxWrapper):
   def __init__(self):
     super().__init__(metrax.PSNR)
 
-    
+
 class Recall(NnxWrapper):
   """An NNX class for the Metrax metric Recall."""
 

--- a/src/metrax/ranking_metrics.py
+++ b/src/metrax/ranking_metrics.py
@@ -136,7 +136,9 @@ class NDCGAtK(DCGAtK):
   where
 
     - If :math:`IDCG@k` is 0, then :math:`NDCG@k` is defined as 0.
-    - The :math:`DCG@k` calculation uses :math:`exp2` gain (:math:`2^{\text{relevance}} - 1`) and standard logarithmic discount (:math:`\frac{1}{\log_2(\text{rank} + 1)}`).
+    - The :math:`DCG@k` calculation uses :math:`exp2` gain
+      (:math:`2^{\text{relevance}} - 1`) and standard logarithmic discount
+      (:math:`\frac{1}{\log_2(\text{rank} + 1)}`).
   """
 
   @classmethod


### PR DESCRIPTION
The rules ruff [uses by default](https://docs.astral.sh/ruff/settings/#lint_select) are `["E4", "E7", "E9", "F", "B", "Q"]`. This PR expands the rules to catch more things like trailing spaces (W), print statements (T20), etc. See the full list of rules here: https://docs.astral.sh/ruff/rules/

Fixes #94