### PR TITLE
Pin JAX version until next release of jax_tpu_embedding

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 absl-py
 clu
-jax[cpu]
+jax[cpu]==0.6.2
 jax_tpu_embedding
 keras-hub
 keras-rs


### PR DESCRIPTION
This should fix CI.