### PR TITLE
remove wandb dependency, let users install wandb only if they want

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
   "jax==0.6.2",
   "numpy==2.1.3",
   "tensorboardX==2.6.4",
-  "wandb==0.22.3",
 ]
 
 [tool.hatch.build]


### PR DESCRIPTION
If wandb is metrax dependency and metrax is tunix dependency, then 100% of tunix users will be installing wandb, which will automatically upload their eval data to wandb.

By removing wandb from metrax dependency, users will be uploading their eval data to wandb only if they manually install wandb.

In the future, Tunix should change their wandb interface such that they will upload to wandb only if they explicitly set the option.