### PR TITLE
docs: restructure metrics reference documentation into category-specific subpages

### DIFF
--- a/docs/api/metrax.CosineSimilarity.rst
+++ b/docs/api/metrax.CosineSimilarity.rst
@@ -1,0 +1,38 @@
+﻿metrax.CosineSimilarity
+=======================
+
+.. currentmodule:: metrax
+
+.. autoclass:: CosineSimilarity
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~CosineSimilarity.__init__
+      ~CosineSimilarity.compute
+      ~CosineSimilarity.compute_value
+      ~CosineSimilarity.empty
+      ~CosineSimilarity.from_fun
+      ~CosineSimilarity.from_model_output
+      ~CosineSimilarity.from_output
+      ~CosineSimilarity.merge
+      ~CosineSimilarity.reduce
+      ~CosineSimilarity.replace
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~CosineSimilarity.total
+      ~CosineSimilarity.count
+   
+   

--- a/docs/api/metrax.MSLE.rst
+++ b/docs/api/metrax.MSLE.rst
@@ -1,0 +1,38 @@
+﻿metrax.MSLE
+===========
+
+.. currentmodule:: metrax
+
+.. autoclass:: MSLE
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~MSLE.__init__
+      ~MSLE.compute
+      ~MSLE.compute_value
+      ~MSLE.empty
+      ~MSLE.from_fun
+      ~MSLE.from_model_output
+      ~MSLE.from_output
+      ~MSLE.merge
+      ~MSLE.reduce
+      ~MSLE.replace
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~MSLE.total
+      ~MSLE.count
+   
+   

--- a/docs/api/metrax.RMSLE.rst
+++ b/docs/api/metrax.RMSLE.rst
@@ -1,0 +1,38 @@
+﻿metrax.RMSLE
+============
+
+.. currentmodule:: metrax
+
+.. autoclass:: RMSLE
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~RMSLE.__init__
+      ~RMSLE.compute
+      ~RMSLE.compute_value
+      ~RMSLE.empty
+      ~RMSLE.from_fun
+      ~RMSLE.from_model_output
+      ~RMSLE.from_output
+      ~RMSLE.merge
+      ~RMSLE.reduce
+      ~RMSLE.replace
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~RMSLE.total
+      ~RMSLE.count
+   
+   

--- a/docs/api/metrax.SpearmanRankCorrelation.rst
+++ b/docs/api/metrax.SpearmanRankCorrelation.rst
@@ -1,0 +1,38 @@
+﻿metrax.SpearmanRankCorrelation
+==============================
+
+.. currentmodule:: metrax
+
+.. autoclass:: SpearmanRankCorrelation
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~SpearmanRankCorrelation.__init__
+      ~SpearmanRankCorrelation.compute
+      ~SpearmanRankCorrelation.compute_value
+      ~SpearmanRankCorrelation.empty
+      ~SpearmanRankCorrelation.from_fun
+      ~SpearmanRankCorrelation.from_model_output
+      ~SpearmanRankCorrelation.from_output
+      ~SpearmanRankCorrelation.merge
+      ~SpearmanRankCorrelation.reduce
+      ~SpearmanRankCorrelation.replace
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~SpearmanRankCorrelation.predictions
+      ~SpearmanRankCorrelation.labels
+   
+   

--- a/docs/audio.rst
+++ b/docs/audio.rst
@@ -3,7 +3,7 @@ Audio
 
 .. currentmodule:: metrax
 
-These metrics are used to evaluate audio and speech processing models.
+A collection of different metrics for audio models.
 
 .. autosummary::
    :toctree: api/

--- a/docs/audio.rst
+++ b/docs/audio.rst
@@ -1,0 +1,12 @@
+Audio
+=====
+
+.. currentmodule:: metrax
+
+These metrics are used to evaluate audio and speech processing models.
+
+.. autosummary::
+   :toctree: api/
+   :template: autosummary/class.rst
+
+   ~SNR

--- a/docs/base.rst
+++ b/docs/base.rst
@@ -3,7 +3,7 @@ Base
 
 .. currentmodule:: metrax
 
-These are base/helper metrics used across Metrax.
+A collection of base metrics for metrax.
 
 .. autosummary::
    :toctree: api/

--- a/docs/base.rst
+++ b/docs/base.rst
@@ -1,0 +1,12 @@
+Base
+====
+
+.. currentmodule:: metrax
+
+These are base/helper metrics used across Metrax.
+
+.. autosummary::
+   :toctree: api/
+   :template: autosummary/class.rst
+
+   ~Average

--- a/docs/classification.rst
+++ b/docs/classification.rst
@@ -3,15 +3,15 @@ Classification
 
 .. currentmodule:: metrax
 
-These metrics are used to evaluate classification models.
+A collection of different metrics for classification models.
 
 .. autosummary::
    :toctree: api/
    :template: autosummary/class.rst
 
-   ~Accuracy
-   ~Precision
-   ~Recall
    ~AUCPR
    ~AUCROC
+   ~Accuracy
    ~FBetaScore
+   ~Precision
+   ~Recall

--- a/docs/classification.rst
+++ b/docs/classification.rst
@@ -1,0 +1,17 @@
+Classification
+==============
+
+.. currentmodule:: metrax
+
+These metrics are used to evaluate classification models.
+
+.. autosummary::
+   :toctree: api/
+   :template: autosummary/class.rst
+
+   ~Accuracy
+   ~Precision
+   ~Recall
+   ~AUCPR
+   ~AUCROC
+   ~FBetaScore

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,8 @@
 
 import os
 import sys
+import importlib
+import metrax
 
 # Import local version of metrax.
 sys.path.insert(0, os.path.abspath('../src'))
@@ -84,8 +86,6 @@ autosummary_generate = True
 
 def _generate_rst_files() -> None:
   """Automates creation of Sphinx RST files for Metrax metrics."""
-  import importlib  # pylint: disable=import-outside-toplevel
-  import metrax  # pylint: disable=import-outside-toplevel
 
   mods = {}
   for name in metrax.__all__:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,5 +135,4 @@ def _generate_rst_files() -> None:
     with open(os.path.join(docs_dir, 'metrax.rst'), 'w', encoding='utf-8') as f:
       f.write(metrax_rst)
 
-
 _generate_rst_files()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,3 +80,64 @@ autodoc_default_options = {
 }
 
 autosummary_generate = True
+
+
+def _generate_rst_files() -> None:
+  """Automates creation of Sphinx RST files for Metrax metrics."""
+  import importlib  # pylint: disable=import-outside-toplevel
+  import metrax  # pylint: disable=import-outside-toplevel
+
+  mods = {}
+  for name in metrax.__all__:
+    mod_name = getattr(metrax, name).__module__
+    mods.setdefault(mod_name, []).append(name)
+
+  docs_dir = os.path.dirname(os.path.abspath(__file__))
+  cats = []
+
+  for mod_name, metrics in mods.items():
+    cat = mod_name.split('.')[-1].replace('_metrics', '')
+    cats.append(cat)
+    title = cat.upper() if len(cat) <= 3 else cat.capitalize()
+    mod = sys.modules.get(mod_name)
+    if not mod:
+      mod = importlib.import_module(mod_name)
+    doc = getattr(mod, '__doc__', '') or ''
+    desc = doc.strip().split('\n\n')[0] if doc else ''
+    items = '\n'.join(f'   ~{m}' for m in sorted(metrics))
+
+    content = (
+        f'{title}\n{"=" * len(title)}\n\n'
+        '.. currentmodule:: metrax\n\n'
+        f'{desc}\n\n'
+        '.. autosummary::\n'
+        '   :toctree: api/\n'
+        '   :template: autosummary/class.rst\n\n'
+        f'{items}\n'
+    )
+    with open(
+        os.path.join(docs_dir, f'{cat}.rst'), 'w', encoding='utf-8'
+    ) as f:
+      f.write(content)
+
+  if cats:
+    toc = '\n'.join(
+        f'   {c}'
+        for c in sorted(cats, key=lambda x: (0 if x == 'base' else 1, x))
+    )
+    intro = (
+        'Metrax provides high-performance, JAX-native evaluation metrics'
+        ' organized into specialized categories. Select a category below to'
+        ' explore the available metrics and their API reference:'
+    )
+    metrax_rst = (
+        f'Metrax Metrics\n==============\n\n{intro}\n\n'
+        f'.. toctree::\n   :maxdepth: 2\n\n{toc}\n'
+    )
+    with open(
+        os.path.join(docs_dir, 'metrax.rst'), 'w', encoding='utf-8'
+    ) as f:
+      f.write(metrax_rst)
+
+
+_generate_rst_files()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,9 +14,9 @@
 
 """Configuration file for the Sphinx documentation builder."""
 
+import importlib
 import os
 import sys
-import importlib
 import metrax
 
 # Import local version of metrax.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.abspath('../src'))
 # -- Project information
 
 project = 'metrax'
-copyright = '2025, The metrax Authors'
+copyright = '2025, The metrax Authors'  # pylint: disable=redefined-builtin
 author = 'The metrax Authors'
 
 release = ''
@@ -115,9 +115,7 @@ def _generate_rst_files() -> None:
         '   :template: autosummary/class.rst\n\n'
         f'{items}\n'
     )
-    with open(
-        os.path.join(docs_dir, f'{cat}.rst'), 'w', encoding='utf-8'
-    ) as f:
+    with open(os.path.join(docs_dir, f'{cat}.rst'), 'w', encoding='utf-8') as f:
       f.write(content)
 
   if cats:
@@ -134,9 +132,7 @@ def _generate_rst_files() -> None:
         f'Metrax Metrics\n==============\n\n{intro}\n\n'
         f'.. toctree::\n   :maxdepth: 2\n\n{toc}\n'
     )
-    with open(
-        os.path.join(docs_dir, 'metrax.rst'), 'w', encoding='utf-8'
-    ) as f:
+    with open(os.path.join(docs_dir, 'metrax.rst'), 'w', encoding='utf-8') as f:
       f.write(metrax_rst)
 
 

--- a/docs/image.rst
+++ b/docs/image.rst
@@ -1,9 +1,9 @@
-Image & Vision
-==============
+Image
+=====
 
 .. currentmodule:: metrax
 
-These metrics are used to evaluate computer vision and image generation models.
+A collection of different metrics for image models.
 
 .. autosummary::
    :toctree: api/

--- a/docs/image.rst
+++ b/docs/image.rst
@@ -1,0 +1,16 @@
+Image & Vision
+==============
+
+.. currentmodule:: metrax
+
+These metrics are used to evaluate computer vision and image generation models.
+
+.. autosummary::
+   :toctree: api/
+   :template: autosummary/class.rst
+
+   ~CosineSimilarity
+   ~Dice
+   ~IoU
+   ~PSNR
+   ~SSIM

--- a/docs/metrax.rst
+++ b/docs/metrax.rst
@@ -1,36 +1,15 @@
 Metrax Metrics
 ==============
 
-.. automodule:: metrax
+Metrax provides high-performance, JAX-native evaluation metrics organized into specialized categories. Select a category below to explore the available metrics and their API reference:
 
-.. autosummary::
-   :toctree: api/
-   :template: autosummary/class.rst
+.. toctree::
+   :maxdepth: 2
 
-   ~AUCPR
-   ~AUCROC
-   ~Accuracy
-   ~Average
-   ~AveragePrecisionAtK
-   ~BLEU
-   ~DCGAtK
-   ~Dice
-   ~FBetaScore
-   ~IoU
-   ~MAE
-   ~MRR
-   ~MSE
-   ~NDCGAtK
-   ~Perplexity
-   ~Precision
-   ~PrecisionAtK
-   ~PSNR
-   ~RMSE
-   ~RSQUARED
-   ~Recall
-   ~RecallAtK
-   ~RougeL
-   ~RougeN
-   ~SNR
-   ~SSIM
-   ~WER
+   base
+   classification
+   regression
+   ranking
+   nlp
+   image
+   audio

--- a/docs/metrax.rst
+++ b/docs/metrax.rst
@@ -7,9 +7,9 @@ Metrax provides high-performance, JAX-native evaluation metrics organized into s
    :maxdepth: 2
 
    base
-   classification
-   regression
-   ranking
-   nlp
-   image
    audio
+   classification
+   image
+   nlp
+   ranking
+   regression

--- a/docs/nlp.rst
+++ b/docs/nlp.rst
@@ -1,0 +1,16 @@
+NLP
+===
+
+.. currentmodule:: metrax
+
+These metrics are used to evaluate Natural Language Processing models.
+
+.. autosummary::
+   :toctree: api/
+   :template: autosummary/class.rst
+
+   ~BLEU
+   ~Perplexity
+   ~RougeL
+   ~RougeN
+   ~WER

--- a/docs/nlp.rst
+++ b/docs/nlp.rst
@@ -3,7 +3,7 @@ NLP
 
 .. currentmodule:: metrax
 
-These metrics are used to evaluate Natural Language Processing models.
+A collection of different metrics for NLP models.
 
 .. autosummary::
    :toctree: api/

--- a/docs/ranking.rst
+++ b/docs/ranking.rst
@@ -1,0 +1,17 @@
+Ranking
+=======
+
+.. currentmodule:: metrax
+
+These metrics are used to evaluate search and ranking systems.
+
+.. autosummary::
+   :toctree: api/
+   :template: autosummary/class.rst
+
+   ~AveragePrecisionAtK
+   ~DCGAtK
+   ~NDCGAtK
+   ~MRR
+   ~PrecisionAtK
+   ~RecallAtK

--- a/docs/ranking.rst
+++ b/docs/ranking.rst
@@ -3,7 +3,7 @@ Ranking
 
 .. currentmodule:: metrax
 
-These metrics are used to evaluate search and ranking systems.
+A collection of different metrics for ranking models.
 
 .. autosummary::
    :toctree: api/
@@ -11,7 +11,7 @@ These metrics are used to evaluate search and ranking systems.
 
    ~AveragePrecisionAtK
    ~DCGAtK
-   ~NDCGAtK
    ~MRR
+   ~NDCGAtK
    ~PrecisionAtK
    ~RecallAtK

--- a/docs/regression.rst
+++ b/docs/regression.rst
@@ -1,0 +1,18 @@
+Regression
+==========
+
+.. currentmodule:: metrax
+
+These metrics are used to evaluate regression models.
+
+.. autosummary::
+   :toctree: api/
+   :template: autosummary/class.rst
+
+   ~MAE
+   ~MSE
+   ~RMSE
+   ~MSLE
+   ~RMSLE
+   ~RSQUARED
+   ~SpearmanRankCorrelation

--- a/docs/regression.rst
+++ b/docs/regression.rst
@@ -3,7 +3,7 @@ Regression
 
 .. currentmodule:: metrax
 
-These metrics are used to evaluate regression models.
+A collection of different metrics for regression models.
 
 .. autosummary::
    :toctree: api/
@@ -11,8 +11,8 @@ These metrics are used to evaluate regression models.
 
    ~MAE
    ~MSE
-   ~RMSE
    ~MSLE
+   ~RMSE
    ~RMSLE
    ~RSQUARED
    ~SpearmanRankCorrelation

--- a/docs/static/custom.css
+++ b/docs/static/custom.css
@@ -2,3 +2,54 @@
 .wy-side-nav-search .wy-nav-top {
     background: transparent;
 }
+
+/* Premium style for the metrics category TOC */
+.toctree-wrapper .toctree-l1 {
+    margin-top: 2rem !important;
+    margin-bottom: 0.75rem !important;
+    list-style-type: none !important; /* Remove default list bullet for categories */
+}
+
+.toctree-wrapper .toctree-l1 > a {
+    font-size: 1.3rem !important;
+    font-weight: 600 !important;
+    color: var(--pst-color-text-base, #1a202c) !important;
+    text-decoration: none !important;
+    border-bottom: 1px solid var(--pst-color-border, #e2e8f0) !important;
+    padding-bottom: 0.4rem !important;
+    display: inline-block !important;
+    width: 100% !important;
+}
+
+.toctree-wrapper .toctree-l2 {
+    margin-top: 0.4rem !important;
+    margin-bottom: 0.4rem !important;
+    list-style-type: none !important; /* Custom spacing instead of default bullets */
+    padding-left: 1.25rem !important;
+    position: relative !important;
+}
+
+/* Elegant custom bullet for metrics */
+.toctree-wrapper .toctree-l2::before {
+    content: "•" !important;
+    color: var(--pst-color-primary, #3182ce) !important; /* Sleek primary color */
+    font-weight: bold !important;
+    display: inline-block !important;
+    width: 1rem !important;
+    margin-left: -1rem !important;
+    position: absolute !important;
+    left: 0.75rem !important;
+}
+
+.toctree-wrapper .toctree-l2 > a {
+    font-size: 1.05rem !important;
+    font-weight: 500 !important;
+    color: var(--pst-color-primary, #2b6cb0) !important;
+    text-decoration: none !important;
+    transition: color 0.15s ease !important;
+}
+
+.toctree-wrapper .toctree-l2 > a:hover {
+    color: var(--pst-color-primary-hover, #1a365d) !important;
+    text-decoration: underline !important;
+}


### PR DESCRIPTION
This PR restructures the flat evaluation metrics page in the Metrax documentation. Instead of listing all metrics on a single, long page, they are now organized into dedicated, logical subpages corresponding to their application domains. 

The documentation generation process is now automated using a newly created hook in conf.py which is run during sphinx-build.

- docs/base.rst: General helper metrics (e.g., `Average`).
- docs/classification.rst: Binary and multi-class evaluation metrics (e.g., `Accuracy, Precision, Recall, AUCPR, AUCROC, FBetaScore`).
- docs/regression.rst: Regression metrics (e.g., `MAE, MSE, RMSE, RSQUARED`).
- docs/ranking.rst: Information retrieval and search ranking metrics (e.g., `AveragePrecisionAtK, DCGAtK, NDCGAtK, MRR, PrecisionAtK, RecallAtK`).
- docs/nlp.rst: Natural Language Processing metrics (e.g., `BLEU, Perplexity, RougeL, RougeN, WER`).
- docs/image.rst: Computer vision metrics (e.g., `Dice, IoU, PSNR, SSIM`).
- docs/audio.rst: Audio metrics (e.g., `SNR`)

Additionally, several public metrics exported in the metrax namespace (`CosineSimilarity, MSLE, RMSLE, SpearmanRankCorrelation`) but previously undocumented have now been added to their respective categories.