### PR TITLE
🧹 [Code Health] Remove unused import in metrax_test.py

### DIFF
--- a/src/metrax/metrax_test.py
+++ b/src/metrax/metrax_test.py
@@ -60,6 +60,7 @@ AUDIO_SHAPE = (2, 16000)
 AUDIO_PREDS = np.random.randn(*AUDIO_SHAPE).astype(np.float32)
 AUDIO_TARGETS = np.random.randn(*AUDIO_SHAPE).astype(np.float32)
 
+
 class MetraxTest(parameterized.TestCase):
 
   @parameterized.named_parameters(

--- a/src/metrax/metrax_test.py
+++ b/src/metrax/metrax_test.py
@@ -17,7 +17,6 @@ from absl.testing import absltest
 from absl.testing import parameterized
 import jax
 import metrax
-import metrax.nnx
 import numpy as np
 
 np.random.seed(42)

--- a/src/metrax/metrax_test.py
+++ b/src/metrax/metrax_test.py
@@ -19,6 +19,7 @@ import jax
 import metrax
 import numpy as np
 
+
 np.random.seed(42)
 BATCHES = 1
 BATCH_SIZE = 8


### PR DESCRIPTION
🎯 **What:** Removed the unused `import metrax.nnx` from `src/metrax/metrax_test.py`.
💡 **Why:** The import was not being used anywhere in the file. Removing it cleans up the codebase and improves code readability and maintainability.
✅ **Verification:** Verified that the removal didn't cause any test failures by running the full unit test suite `python3 -m unittest src/metrax/metrax_test.py`.
✨ **Result:** Improved code health in `src/metrax/metrax_test.py` by eliminating dead code (the unused import) without breaking functionality.

---
*PR created automatically by Jules for task [11119655779190449620](https://jules.google.com/task/11119655779190449620) started by @rni418*