### PR TITLE
Add pre-commit hook with Ruff linting & formatting and update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ jobs:
       - uses: actions/checkout@v6
       - name: Lint
         uses: astral-sh/ruff-action@v2
+        with:
+          args: "check"
+      - name: Format Check
+        uses: astral-sh/ruff-action@v2
+        with:
+          args: "format --check"
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.2
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,18 @@ Please make sure that your PR passes all tests by running `pytest ./src/` on you
 local machine. Also, you can run only tests that are affected by your code
 changes, but you will need to select them manually.
 
-Metrax uses [ruff](https://github.com/astral-sh/ruff) for linting. Before
-sending a PR please run `ruff check` to catch any issues.
+Metrax uses [ruff](https://github.com/astral-sh/ruff) for linting and formatting, managed via [pre-commit](https://pre-commit.com/).
+
+To set up pre-commit hooks locally:
+```bash
+pip install -e ".[dev]"
+pre-commit install
+```
+
+Once installed, pre-commit will automatically run `ruff` linting and formatting checks whenever you commit changes. You can also run the hooks manually on all files:
+```bash
+pre-commit run --all-files
+```
 
 ## Community Guidelines
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
   "nltk>=3.9.1",
   "pytest>=8.4.1",
   "Pillow>=9.0.0",
+  "pre-commit",
   "protobuf>=5.29.5",
   "rouge-score>=0.1.2",
   "scikit-learn>=1.7.1",


### PR DESCRIPTION
Adds automated code linting and formatting via pre-commit and ruff.

Implemented Changes:
`.pre-commit-config.yaml`: Configured astral-sh/ruff-pre-commit hooks for linting (ruff with --fix) and code formatting (ruff-format).
`pyproject.toml`: Added pre-commit to project.optional-dependencies.dev.
`CONTRIBUTING.md`: Updated contributor guidelines with instructions on installing (pre-commit install) and running (pre-commit run --all-files) hooks locally.
`.github/workflows/ci.yml`: Added a Format Check step (ruff format --check) alongside ruff check in GitHub Actions CI.

Testing:
Verified pre-commit hooks execute correctly on git commit.
Verified ruff format and ruff check pass on the repository.
Verified all unit tests pass with pytest ./src/.